### PR TITLE
Updates the version of Microsoft.Extensions.Logging.AzureAppServices

### DIFF
--- a/DotNetCoreSqlDb/DotNetCoreSqlDb.csproj
+++ b/DotNetCoreSqlDb/DotNetCoreSqlDb.csproj
@@ -12,7 +12,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="6.0.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Current version of "ASP.NET Core Logging Integration" **extension on Azure App Service** is 6.0.3 (which is the latest version of released nuget package). Since the current project was refering v 6.0.0, it created conflict during startup of sample appliaction when deployed to AzureAppService. The sample application would work for the first time when deployed, but will fail after subsequent restart (after the extension gets added). Ref: [Tutorial: Deploy an ASP.NET Core and Azure SQL Database app to Azure App Service](https://docs.microsoft.com/en-us/azure/app-service/tutorial-dotnetcore-sqldb-app?tabs=azure-portal%2Cvisualstudio-deploy%2Cdeploy-instructions-azure-portal%2Cazure-portal-logs%2Cazure-portal-resources)

